### PR TITLE
Fix type error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if (NOT MSVC)
 			-fvisibility-inlines-hidden
     )
 	if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") AND WIN32))
-		target_compile_options (${TARGET} PRIVATE -fPIC)
+		target_compile_options (SynthEngineDemo PRIVATE -fPIC)
 	endif ()
 	target_link_options (SynthEngineDemo PRIVATE
 			-shared

--- a/src/RealTimeRenderer.cpp
+++ b/src/RealTimeRenderer.cpp
@@ -40,7 +40,7 @@ public:
 	}
 
 	void readMaxLevels(
-		int64_t /*startSample*/, int64_t /*numSamples*/,
+		juce::int64 /*startSample*/, juce::int64 /*numSamples*/,
 		juce::Range<float>* results, int /*numChannelsToRead*/) override {
 		if (results) {
 			results->setStart(-1.0f);
@@ -48,7 +48,7 @@ public:
 		}
 	};
 	void readMaxLevels(
-		int64_t startSample, int64_t numSamples,
+		juce::int64 startSample, juce::int64 numSamples,
 		float& lowestLeft, float& highestLeft,
 		float& lowestRight, float& highestRight) override {
 		lowestLeft = lowestRight = -1.0f;
@@ -61,7 +61,7 @@ public:
 
 	bool readSamples(
 		int* const* destChannels, int numDestChannels,
-		int startOffsetInDestBuffer, int64_t startSampleInFile, int numSamples) override {
+		int startOffsetInDestBuffer, juce::int64 startSampleInFile, int numSamples) override {
 		for (int i = 0; i < numDestChannels; i++) {
 			/** Get Buffer Pointer */
 			int bufferChannel = i % this->buffer.getNumChannels();


### PR DESCRIPTION
In some compilers, `int64_t` is not the same type as `juce::int64`, which causes errors. Changed `int64_t` to `juce::int64` to fix it.